### PR TITLE
Working docker-compose OAuth server

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,17 @@ To run over HTTPS replace the last command above with the following, replacing t
 docker run -d -p 5001:443 -e ASPNETCORE_URLS="https://+" -e ASPNETCORE_HTTPS_PORT=5001 -e ASPNETCORE_Kestrel__Certificates__Default__Path=/certs/localhost.pfx -e "ConnectionStrings:DefaultConnection=Server=DB_HOST;Port=DB_PORT;Database=DB_DBNAME;User Id=DB_USERID;Password=DB_PASS" -v /path/to/certs:/certs --name gpconnect-user-portal-application gpconnect-user-portal-application
 ```
 
+## Local Auth
+
+Add the following to your `/etc/hosts` (or `C:\Windows\System32\Drivers\etc\hosts`)
+
+```
+127.0.0.1     auth.docker.internal
+```
+
 ## Links
 
 - [NHS UK frontend](https://github.com/nhsuk/nhsuk-frontend)
 - [GOV.UK service manual - technology](https://www.gov.uk/service-manual/technology)
 
- 
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,28 @@ services:
     image: ghcr.io/navikt/mock-oauth2-server:0.4.8
     ports:
       - 8080:8080
+    hostname: auth.docker.internal
+    environment:
+      JSON_CONFIG: |-
+        {
+          "interactiveLogin": false,
+          "tokenCallbacks": [
+            {
+              "issuerId": "default",
+              "tokenExpiry": 120,
+              "requestMappings": [
+                {
+                  "requestParam": "client_id",
+                  "match": "*",
+                  "claims": {
+                    "sub": "adrian",
+                    "email address": "adrian.wilkins3@nhs.net"
+                  }
+                }
+              ]
+            }
+          ]
+        }
 
 
   user-portal:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,8 @@ services:
                   "requestParam": "client_id",
                   "match": "*",
                   "claims": {
-                    "sub": "adrian",
-                    "email address": "adrian.wilkins3@nhs.net"
+                    "sub": "testy.mctestface",
+                    "email address": "testy.mctestface@nhs.net"
                   }
                 }
               ]

--- a/source/gpconnect-user-portal.Admin/appsettings.Development.json
+++ b/source/gpconnect-user-portal.Admin/appsettings.Development.json
@@ -7,14 +7,15 @@
     }
   },
   "Sso": {
+    "Flow": "code",
     "AuthScheme": "Cookies",
     "ChallengeScheme": "OpenIdConnect",
     "RequireHttpsMetadata": false,
-    "AuthEndpoint": "https://fs.nhs.net/adfs/oauth2/authorize/",
-    "TokenEndpoint": "https://fs.nhs.net/adfs/oauth2/token/",
-    "MetadataEndpoint": "https://fs.nhs.net/adfs/.well-known/openid-configuration",
-    "ClientId": "f1a6b2e9-73ca-451a-9fcb-6a0ac31900ef",
-    "ClientSecret": "HCYYCsDXv2CZa52Dxlf6s9PgnlZCTOGfqyV24eJ3",
+    "AuthEndpoint": "http://auth.docker.internal:8080/default/authorize",
+    "TokenEndpoint": "http://auth.docker.internal:8080/default/token",
+    "MetadataEndpoint": "http://auth.docker.internal:8080/default/.well-known/openid-configuration",
+    "ClientId": "debug-client",
+    "ClientSecret": "not-really-very-secret",
     "CallbackPath": "/auth/externallogin",
     "SignedOutCallbackPath": "/auth/externallogout"
   }

--- a/source/gpconnect-user-portal.Admin/appsettings.json
+++ b/source/gpconnect-user-portal.Admin/appsettings.json
@@ -8,10 +8,9 @@
     "ServerUrl": "",
     "Source": "",
     "SourceType": "",
-    "UseProxy": true,  // why is this null ....?
+    "UseProxy": true,
     "ProxyUser": "secret",
     "ProxyPassword": "secret"
-    //'0E201D4D-3F48-4D5C-A4DE-EEF8B08A198E','index','https://splunk-server:8088','${logger}','_json', 'true', '***proxy_user***', '***proxy_password***');
   },
   "Sso": {
     "Flow": "code id_token",

--- a/source/gpconnect-user-portal.Admin/appsettings.json
+++ b/source/gpconnect-user-portal.Admin/appsettings.json
@@ -2,25 +2,29 @@
   "Logging": {
   },
   "Splunk": {
-    "Token": "D5442FDE-6707-4A53-B919-98FC4D6DAC72", 
-    "Channel": "", 
-    "Index": "", 
-    "ServerUrl": "", 
-    "Source": "", 
-    "SourceType": "", 
+    "Token": "D5442FDE-6707-4A53-B919-98FC4D6DAC72",
+    "Channel": "",
+    "Index": "",
+    "ServerUrl": "",
+    "Source": "",
+    "SourceType": "",
     "UseProxy": true,  // why is this null ....?
-    "ProxyUser": "secret", 
+    "ProxyUser": "secret",
     "ProxyPassword": "secret"
     //'0E201D4D-3F48-4D5C-A4DE-EEF8B08A198E','index','https://splunk-server:8088','${logger}','_json', 'true', '***proxy_user***', '***proxy_password***');
   },
   "Sso": {
-    "AuthScheme": "Application",
-    "ChallengeScheme": "",
-    "ClientId": "",
-    "ClientSecret": "",
-    "CallbackPath": "",
-    "SignedOutCallbackPath": "",
-    "RequireHttpsMetadata": true
+    "Flow": "code id_token",
+    "AuthScheme": "Cookies",
+    "ChallengeScheme": "OpenIdConnect",
+    "RequireHttpsMetadata": true,
+    "AuthEndpoint": "https://fs.nhs.net/adfs/oauth2/authorize/",
+    "TokenEndpoint": "https://fs.nhs.net/adfs/oauth2/token/",
+    "MetadataEndpoint": "https://fs.nhs.net/adfs/.well-known/openid-configuration",
+    "ClientId": "f1a6b2e9-73ca-451a-9fcb-6a0ac31900ef",
+    "ClientSecret": "HCYYCsDXv2CZa52Dxlf6s9PgnlZCTOGfqyV24eJ3",
+    "CallbackPath": "/auth/externallogin",
+    "SignedOutCallbackPath": "/auth/externallogout"
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {

--- a/source/gpconnect-user-portal.Core/Configuration/Infrastructure/Authentication/AuthenticationExtensions.cs
+++ b/source/gpconnect-user-portal.Core/Configuration/Infrastructure/Authentication/AuthenticationExtensions.cs
@@ -53,7 +53,7 @@ namespace gpconnect_user_portal.Core.Configuration.Infrastructure.Authentication
                     options.Scope.Add("openid");
                     options.Scope.Add("profile");
                     options.Scope.Add("email");
-                    options.ResponseType = OpenIdConnectResponseType.CodeIdToken;
+                    options.ResponseType = _ssoConfig.Flow;
 
                     options.ClientId = _ssoConfig.ClientId;
                     options.ClientSecret = _ssoConfig.ClientSecret;

--- a/source/gpconnect-user-portal.DTO/Response/Configuration/Sso.cs
+++ b/source/gpconnect-user-portal.DTO/Response/Configuration/Sso.cs
@@ -2,6 +2,8 @@
 {
     public class Sso
     {
+
+        public string Flow { get; set; }
         public string ClientId { get; set; }
         public string ClientSecret { get; set; }
         public string CallbackPath { get; set; }


### PR DESCRIPTION
This adds an OAuth server and configures it to automatically sign in as a test user.

This should enable acceptance tests to perform all authorized flows on the application in the docker stack.