### PR TITLE
Reinstate database mapping init

### DIFF
--- a/source/gpconnect-user-portal.Admin/Startup.cs
+++ b/source/gpconnect-user-portal.Admin/Startup.cs
@@ -1,6 +1,8 @@
 using Autofac;
+
 using gpconnect_user_portal.Core.Configuration.Infrastructure;
 using gpconnect_user_portal.Core.Configuration.Logging;
+using gpconnect_user_portal.Core.Configuration.Mapping;
 using gpconnect_user_portal.Core.Configuration.Infrastructure.Authentication;
 using gpconnect_user_portal.DAL;
 
@@ -15,10 +17,11 @@ namespace gpconnect_user_portal.Admin
         {
             if (configuration == null) throw new ArgumentNullException(nameof(configuration));
             if (configuration.GetConnectionString(ConnectionStrings.DefaultConnection) == null) throw new ArgumentNullException(nameof(ConnectionStrings.DefaultConnection));
+            MappingExtensions.ConfigureMappingServices();
 
             _configuration = configuration;
             _webHostEnvironment = webHostEnvironment;
-        }        
+        }
 
         public void ConfigureServices(IServiceCollection services)
         {


### PR DESCRIPTION
This was in the configuration classes that have now been removed.

Moved to app startup so that the database works again.