### PR TITLE
Add a Dockerfile for the database migrator

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,0 +1,18 @@
+FROM amazon/aws-cli:2.7.16 as aws-cli
+
+FROM flyway/flyway:9.0.1-azure as flyway
+
+FROM library/amazoncorretto:11.0.15
+
+COPY --from=aws-cli /usr/local/aws-cli/v2/current/ /usr/local/aws-cli/v2/current/
+COPY --from=aws-cli /usr/local/bin/ /usr/local/bin/
+COPY --from=flyway /flyway/ /flyway/
+
+ENV PATH=/flyway:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+COPY . /flyway/sql
+
+ENV FLYWAY_EDITION=community
+ENV FLYWAY_PLACEHOLDERS_logger: ndsa
+
+ENTRYPOINT [ "/flyway/flyway" ]


### PR DESCRIPTION
This

- Creates a Flyway docker image that also has the AWS CLI
  - This is intended so that we can fetch secrets in the image
  - Need to mix and match Java implementations
    - Flyway is build on Alpine Linux (musl)
    - AWS CLI image is built on glibc
    - Easier to move Java code to glibc JDK than rebuild AWS CLI
- Add the database schema to the image so we don't have to e.g. use
  s3 to store our schema files